### PR TITLE
Multiline result print as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ require('goplay').setup()
   template = require("goplay.templates").default, -- template which will be used as the default content for the playground
   mode = "vsplit", -- current/split/[vsplit] specifies where the playground will be opened
   playgroundDirName = "goplayground", -- a name of the directory under GOPATH/src where the playground will be saved
-  tempPlaygroundDirName = "goplayground_temp" -- a name of the directory under GOPATH/src where the temporary playground will be saved. This option is used when you need to execute a file
+  tempPlaygroundDirName = "goplayground_temp", -- a name of the directory under GOPATH/src where the temporary playground will be saved. This option is used when you need to execute a file
+  output_mode = "formatted", -- [formatted]/raw mode to display output
 }
 ```
 

--- a/lua/goplay/init.lua
+++ b/lua/goplay/init.lua
@@ -7,12 +7,18 @@ local modes = {
   vsplit = "vsplit",
 }
 
+local output_modes = {
+  formatted = "formatted",
+  raw = "raw",
+}
+
 local M = {
   -- Data which can be configured
   template = templates.default, -- template which will be used as the default content for the playground
   mode = modes.vsplit, -- current/split/[vsplit] specifies where the playground will be opened
   playgroundDirName = "goplayground", -- a name of the directory under GOPATH/src where the playground will be saved
   tempPlaygroundDirName = "goplayground_temp", -- a name of the directory under GOPATH/src where the temporary playground will be saved. This option is used when you need to execute a file
+  output_mode = output_modes.formatted,
 
   -- Data which might be used for configuring
   templates = templates,
@@ -26,6 +32,7 @@ function M.setup(opts)
 
   M.template = opts.template or M.template
   M.mode = opts.mode or M.mode
+  M.output_mode = opts.output_mode or M.output_mode
   M.playgroundDirName = opts.playgroundDirName or M.playgroundDirName
   M.tempPlaygroundDirName = opts.tempPlaygroundDirName or M.tempPlaygroundDirName
   M.goPath = opts.goPath or utils._os_capture("go env GOPATH", false)
@@ -51,15 +58,23 @@ function M.goExecFileAsPlayground()
   if not utils._isDirExist(M._tempGoPlaygroundPath) then M._createPlaygroundFolder(M._tempGoPlaygroundPath) end
   M._fillPlaygroundFile(M._tempFilePath, content)
 
-  utils._execGoFile(M._tempFilePath)
+  M.printExecResult(utils._execGoFile(M._tempFilePath))
   os.execute("rm -rf " .. M._tempGoPlaygroundPath)
 end
 
 function M.goExecPlayground()
   if utils._isFileExist(M._filePath) then
-    utils._execGoFile(M._filePath)
+    M.printExecResult(utils._execGoFile(M._filePath))
   else
     print("Playground is not created yet. Please use :GPOpen or :GPToggle to create a playground")
+  end
+end
+
+function M.printExecResult(result)
+  if M.output_mode == output_modes.raw then
+    vim.api.nvim_echo({ { result } }, true, {})
+  else
+    print(utils._format_result(result))
   end
 end
 

--- a/lua/goplay/utils.lua
+++ b/lua/goplay/utils.lua
@@ -4,7 +4,12 @@ function Utils._os_capture(cmd, raw)
   local f = assert(io.popen(cmd, 'r'))
   local s = assert(f:read('*a'))
   f:close()
+
   if raw then return s end
+  return Utils._format_result(s)
+end
+
+function Utils._format_result(s)
   s = string.gsub(s, '^%s+', '')
   s = string.gsub(s, '%s+$', '')
   s = string.gsub(s, '[\n\r]+', ' ')
@@ -20,7 +25,7 @@ function Utils._isFileExist(path)
 end
 
 function Utils._execGoFile(filepath)
-  print(Utils._os_capture("go run " .. filepath, false))
+  return Utils._os_capture("go run " .. filepath, true)
 end
 
 return Utils


### PR DESCRIPTION
If playbook has multiple prints, or multiline print its probably better to print it out without formatting. Added option to select output mode:

```lua
      require("goplay").setup({
        output_mode = "raw", -- "formatted" by default
      })
```

![Screenshot from 2023-03-11 18-10-52](https://user-images.githubusercontent.com/37133/224503391-1b5e59fa-522e-4420-a936-57934846b3d4.png)
