### PR TITLE
fix: fix Invalid command: "bdelete!" error

### DIFF
--- a/lua/goplay/init.lua
+++ b/lua/goplay/init.lua
@@ -95,7 +95,7 @@ function M.goPlaygroundOpen()
 end
 
 function M.goPlaygroundClose()
-  vim.cmd["bdelete!"](M._activeBuf)
+  vim.cmd.bdelete { M._activeBuf, bang = true }
   M._activeBuf = nil
 end
 


### PR DESCRIPTION
The original version with `["bdelete!"]` gives me the error: `Invalid command: "bdelete!"` (Neovim v0.10.0). 
I believe the syntax proposed in the PR is backward compatible and should not cause any issues in older versions.